### PR TITLE
Fix device choice based on interface

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -31,9 +31,11 @@ func main() {
 		// TREZOR
 		// 0x534c : 21324 vendor
 		// 0x0001 : 1     product
+		// 0x00   : Main Trezor Interface
 		// 0x01   : Main Trezor Endpoint
 		if info.Vendor == 21324 && info.Product == 1 {
 			numberDevices++
+			device.SetInterface(0x00)
 			client.SetTransport(device)
 			device.SetEndpoint(0x01)
 		}

--- a/example/main.go
+++ b/example/main.go
@@ -31,9 +31,11 @@ func main() {
 		// TREZOR
 		// 0x534c : 21324 vendor
 		// 0x0001 : 1     product
+		// 0x01   : Main Trezor Endpoint
 		if info.Vendor == 21324 && info.Product == 1 {
 			numberDevices++
 			client.SetTransport(device)
+			device.SetEndpoint(0x01)
 		}
 
 	})

--- a/example/main.go
+++ b/example/main.go
@@ -32,12 +32,9 @@ func main() {
 		// 0x534c : 21324 vendor
 		// 0x0001 : 1     product
 		// 0x00   : Main Trezor Interface
-		// 0x01   : Main Trezor Endpoint
-		if info.Vendor == 21324 && info.Product == 1 {
+		if info.Vendor == 21324 && info.Product == 1 && info.Interface == 0 {
 			numberDevices++
-			device.SetInterface(0x00)
 			client.SetTransport(device)
-			device.SetEndpoint(0x01)
 		}
 
 	})


### PR DESCRIPTION
Pending https://github.com/zserge/hid/pull/1#issuecomment-244901988 this will remove the need to specify endpoints and interfaces directly, as with the fixed walker 1 "Device" structure is returned for every Interface.

This makes the code backwards compatible with older firmware as well, since the main Trezor Interface was always at 0.
