### PR TITLE
Fixed "go vet ./..." issues

### DIFF
--- a/pb/google/protobuf/descriptor.pb.go
+++ b/pb/google/protobuf/descriptor.pb.go
@@ -754,7 +754,7 @@ func (*FileOptions) ProtoMessage()               {}
 func (*FileOptions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{8} }
 
 var extRange_FileOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*FileOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -880,7 +880,7 @@ func (*MessageOptions) ProtoMessage()               {}
 func (*MessageOptions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{9} }
 
 var extRange_MessageOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*MessageOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -989,7 +989,7 @@ func (*FieldOptions) ProtoMessage()               {}
 func (*FieldOptions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{10} }
 
 var extRange_FieldOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*FieldOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -1072,7 +1072,7 @@ func (*EnumOptions) ProtoMessage()               {}
 func (*EnumOptions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{11} }
 
 var extRange_EnumOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*EnumOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -1114,7 +1114,7 @@ func (*EnumValueOptions) ProtoMessage()               {}
 func (*EnumValueOptions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{12} }
 
 var extRange_EnumValueOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*EnumValueOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -1147,7 +1147,7 @@ func (*ServiceOptions) ProtoMessage()               {}
 func (*ServiceOptions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{13} }
 
 var extRange_ServiceOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*ServiceOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -1180,7 +1180,7 @@ func (*MethodOptions) ProtoMessage()               {}
 func (*MethodOptions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{14} }
 
 var extRange_MethodOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*MethodOptions) ExtensionRangeArray() []proto.ExtensionRange {

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -581,8 +581,8 @@ func NewShell(client *tesoro.Client) {
 					var eNonce string
 					eNonce, msgType = s.call(s.client.SetEntryNonce(entry.Title, entry.Username, nonce))
 					entry.Nonce = hex.EncodeToString([]byte(eNonce))
-					entry.Password = tesoro.EncryptedData{"Buffer", tesoro.EncryptEntry("\"MySecretPassword"+rnd+"\"", nonce)}
-					entry.SafeNote = tesoro.EncryptedData{"Buffer", tesoro.EncryptEntry("\"My Safe Note is safe "+rnd+"\"", nonce)}
+					entry.Password = tesoro.EncryptedData{Type: "Buffer", Data: tesoro.EncryptEntry("\"MySecretPassword"+rnd+"\"", nonce)}
+					entry.SafeNote = tesoro.EncryptedData{Type: "Buffer", Data: tesoro.EncryptEntry("\"My Safe Note is safe "+rnd+"\"", nonce)}
 
 					max := 0
 					for k, _ := range data.Entries {


### PR DESCRIPTION
```
# github.com/conejoninja/tesoro/pb/google/protobuf
pb/google/protobuf/descriptor.pb.go:757: github.com/conejoninja/tesoro/vendor/github.com/golang/protobuf/proto.ExtensionRange composite literal uses unkeyed fields
pb/google/protobuf/descriptor.pb.go:883: github.com/conejoninja/tesoro/vendor/github.com/golang/protobuf/proto.ExtensionRange composite literal uses unkeyed fields
pb/google/protobuf/descriptor.pb.go:992: github.com/conejoninja/tesoro/vendor/github.com/golang/protobuf/proto.ExtensionRange composite literal uses unkeyed fields
pb/google/protobuf/descriptor.pb.go:1075: github.com/conejoninja/tesoro/vendor/github.com/golang/protobuf/proto.ExtensionRange composite literal uses unkeyed fields
pb/google/protobuf/descriptor.pb.go:1117: github.com/conejoninja/tesoro/vendor/github.com/golang/protobuf/proto.ExtensionRange composite literal uses unkeyed fields
pb/google/protobuf/descriptor.pb.go:1150: github.com/conejoninja/tesoro/vendor/github.com/golang/protobuf/proto.ExtensionRange composite literal uses unkeyed fields
pb/google/protobuf/descriptor.pb.go:1183: github.com/conejoninja/tesoro/vendor/github.com/golang/protobuf/proto.ExtensionRange composite literal uses unkeyed fields
# github.com/conejoninja/tesoro/shell
shell/shell.go:584: github.com/conejoninja/tesoro.EncryptedData composite literal uses unkeyed fields
shell/shell.go:585: github.com/conejoninja/tesoro.EncryptedData composite literal uses unkeyed fields
```